### PR TITLE
Decrement margin left on center image

### DIFF
--- a/src/App.scss
+++ b/src/App.scss
@@ -151,7 +151,7 @@ a {
             height: 100px;
             border: solid 6px #fff;
             border-radius: 50%;
-            margin-left: 50px;
+            margin-left: 49px;
             margin-top: 10px;
           }
         }


### PR DESCRIPTION
The margin was too large and it overlapped the outer image so that you could see the smaller image outside of the larger image

## Before

![image](https://user-images.githubusercontent.com/29359616/55595851-bb4ea780-5713-11e9-82d1-5421f414f4da.png)

## After

![image](https://user-images.githubusercontent.com/29359616/55596036-ae7e8380-5714-11e9-8eed-206dcb4fc0ed.png)

(The red is only there for demo purposes, _**not in the PR**_)