### PR TITLE
Fixed an accessibility issue on Slack "email" input form element

### DIFF
--- a/src/pages/home/Slack.tsx
+++ b/src/pages/home/Slack.tsx
@@ -8,7 +8,12 @@ export default function Slack() {
       action="/.netlify/functions/request-slack-invite"
     >
       <h2>Enter your email to join our Slack!</h2>
-      <input placeholder="email" name="email" type="email" />
+      <input
+        aria-label="enter email"
+        placeholder="email"
+        name="email"
+        type="email"
+      />
       <button type="submit">Submit</button>
     </form>
   );


### PR DESCRIPTION
This PR fixes the accessibility (a11y) issue on Slack "email" input form element mentioned in issue #36 

Added `aria-label` to describe what the input form is.