### PR TITLE
Convert px font-size values to rem

### DIFF
--- a/src/css/styles.css
+++ b/src/css/styles.css
@@ -2,7 +2,8 @@
 
 :root {
   --color-blue: #5776bf;
-  --color-grey: #797a80;
+  --color-grey: #575962;
+  /* --color-grey: #797a80; not a11y */
   --color-light-grey: #f8f8f8;
   --color-purple: #5a84e8;
 
@@ -27,7 +28,7 @@ html {
 
 body {
   font-family: Rubik, Helvetica, Arial, sans-serif;
-  font-size: 20px;
+  font-size: 1.25rem;
   line-height: 1.6;
   color: var(--color-grey);
   padding: 0;
@@ -52,17 +53,17 @@ h3 {
 }
 
 h1 {
-  font-size: 56px;
+  font-size: 3.5rem;
   font-weight: 300;
 }
 
 h2 {
-  font-size: 44px;
+  font-size: 2.75rem;
   font-weight: 300;
 }
 
 h3 {
-  font-size: 20px;
+  font-size: 1.25rem;
   font-weight: 300;
 }
 
@@ -71,7 +72,7 @@ h3 {
 }
 
 .subhead {
-  font-size: 28px;
+  font-size: 1.75rem;
 }
 
 .ui.button {
@@ -116,7 +117,7 @@ a:hover {
 .cfp-submit-link {
   color: var(--color-button-text);
   background-color: var(--color-light-grey);
-  font-size: 14px;
+  font-size: 0.875rem;
   padding: 10px 15px;
   text-decoration: none;
 }
@@ -168,7 +169,7 @@ a:hover {
   align-items: center;
   border-radius: 2px;
   display: inline-flex;
-  font-size: 16px;
+  font-size: 1rem;
   margin: 5px;
   padding: 10px 15px;
   text-align: center;
@@ -233,7 +234,7 @@ a:hover {
 
 .footer-copyright {
   color: var(--color-light-grey);
-  font-size: 12px;
+  font-size: 0.75rem;
   margin: 0;
   padding: 0;
 }
@@ -381,7 +382,7 @@ a:hover {
   height: 50px;
   line-height: 50px;
   padding: 20px;
-  font-size: 30px;
+  font-size: 1.875rem;
   box-sizing: border-box;
   border: 1px solid var(--color-blue);
 }
@@ -396,7 +397,7 @@ a:hover {
   border-radius: 4px;
   color: var(--color-button-text);
   cursor: pointer;
-  font-size: 22px;
+  font-size: 1.375rem;
   height: 50px;
   margin-top: 20px;
   width: 500px;
@@ -443,24 +444,24 @@ a:hover {
 }
 @media only screen and (max-width: 640px) {
   h1 {
-    font-size: 40px;
+    font-size: 2.5rem;
   }
 
   h2 {
-    font-size: 30px;
+    font-size: 1.875rem;
   }
 
   h3 {
-    font-size: 18px;
+    font-size: 1.125rem;
   }
 
   .subhead {
-    font-size: 22px;
+    font-size: 1.375rem;
   }
 
   li,
   p {
-    font-size: 14px;
+    font-size: 0.875rem;
   }
 
   .cfp-container {
@@ -481,7 +482,7 @@ a:hover {
     margin-top: 15px;
     width: 90%;
     text-align: center;
-    font-size: 20px;
+    font-size: 1.25rem;
   }
 
   .code-of-conduct-container {
@@ -498,7 +499,7 @@ a:hover {
     border-radius: 2px;
     display: inline-flex;
     height: 50px;
-    font-size: 16px;
+    font-size: 1rem;
     margin: 5px;
     padding-left: 20px;
     text-align: center;
@@ -536,7 +537,7 @@ a:hover {
   }
 
   .organizers-ul p {
-    font-size: 20px;
+    font-size: 1.25rem;
     margin: 30px 0 50px;
   }
 

--- a/src/css/styles.css
+++ b/src/css/styles.css
@@ -2,8 +2,7 @@
 
 :root {
   --color-blue: #5776bf;
-  --color-grey: #575962;
-  /* --color-grey: #797a80; not a11y */
+  --color-grey: #797a80;
   --color-light-grey: #f8f8f8;
   --color-purple: #5a84e8;
 


### PR DESCRIPTION
There are some easy wins on the site for a11y.  Only got through font-sizes but now my computer is dying and I'm too lazy to find the charger 😴 

Changes `px` values to `rem` for the `font-sizes`.  This makes the site play nicely with custom browser/os font settings.  Kathleen has a [great article](https://www.24a11y.com/2019/pixels-vs-relative-units-in-css-why-its-still-a-big-deal/) about it if you're interested in more info.

All fonts should be the same on the site, but please spot check.  Assuming the default base of `16px`